### PR TITLE
Fix to emit at most 76 chars per line

### DIFF
--- a/export.go
+++ b/export.go
@@ -174,10 +174,11 @@ func (w *messageWriter) export() *mail.Message {
 	return &mail.Message{Header: w.header, Body: w.buf}
 }
 
-// As defined in RFC 5322, 2.1.1.
-const maxLineLen = 78
+// As required by RFC 2045, 6.7. (page 21) for quoted-printable, and
+// RFC 2045, 6.8. (page 25) for base64.
+const maxLineLen = 76
 
-// base64LineWriter limits text encoded in base64 to 78 characters per line
+// base64LineWriter limits text encoded in base64 to 76 characters per line
 type base64LineWriter struct {
 	w       io.Writer
 	lineLen int
@@ -203,7 +204,7 @@ func (w *base64LineWriter) Write(p []byte) (int, error) {
 	return n + len(p), nil
 }
 
-// qpLineWriter limits text encoded in quoted-printable to 78 characters per
+// qpLineWriter limits text encoded in quoted-printable to 76 characters per
 // line
 type qpLineWriter struct {
 	w       io.Writer

--- a/gomail_test.go
+++ b/gomail_test.go
@@ -432,13 +432,13 @@ func TestQpLineLength(t *testing.T) {
 	msg.SetHeader("From", "from@example.com")
 	msg.SetHeader("To", "to@example.com")
 	msg.SetBody("text/plain",
-		strings.Repeat("0", 79)+"\r\n"+
-			strings.Repeat("0", 78)+"à\r\n"+
-			strings.Repeat("0", 77)+"à\r\n"+
+		strings.Repeat("0", 77)+"\r\n"+
 			strings.Repeat("0", 76)+"à\r\n"+
 			strings.Repeat("0", 75)+"à\r\n"+
-			strings.Repeat("0", 78)+"\r\n"+
-			strings.Repeat("0", 79)+"\n")
+			strings.Repeat("0", 74)+"à\r\n"+
+			strings.Repeat("0", 73)+"à\r\n"+
+			strings.Repeat("0", 76)+"\r\n"+
+			strings.Repeat("0", 77)+"\n")
 
 	want := message{
 		from: "from@example.com",
@@ -448,13 +448,13 @@ func TestQpLineLength(t *testing.T) {
 			"Content-Type: text/plain; charset=UTF-8\r\n" +
 			"Content-Transfer-Encoding: quoted-printable\r\n" +
 			"\r\n" +
-			strings.Repeat("0", 78) + "=\r\n0\r\n" +
-			strings.Repeat("0", 78) + "=\r\n=C3=A0\r\n" +
-			strings.Repeat("0", 77) + "=\r\n=C3=A0\r\n" +
+			strings.Repeat("0", 76) + "=\r\n0\r\n" +
 			strings.Repeat("0", 76) + "=\r\n=C3=A0\r\n" +
-			strings.Repeat("0", 75) + "=C3=\r\n=A0\r\n" +
-			strings.Repeat("0", 78) + "\r\n" +
-			strings.Repeat("0", 78) + "=\r\n0\n",
+			strings.Repeat("0", 75) + "=\r\n=C3=A0\r\n" +
+			strings.Repeat("0", 74) + "=\r\n=C3=A0\r\n" +
+			strings.Repeat("0", 73) + "=C3=\r\n=A0\r\n" +
+			strings.Repeat("0", 76) + "\r\n" +
+			strings.Repeat("0", 76) + "=\r\n0\n",
 	}
 
 	testMessage(t, msg, 0, want)
@@ -474,7 +474,7 @@ func TestBase64LineLength(t *testing.T) {
 			"Content-Type: text/plain; charset=UTF-8\r\n" +
 			"Content-Transfer-Encoding: base64\r\n" +
 			"\r\n" +
-			strings.Repeat("MDAw", 19) + "MA\r\n==",
+			strings.Repeat("MDAw", 19) + "\r\nMA==",
 	}
 
 	testMessage(t, msg, 0, want)


### PR DESCRIPTION
From RFC 2045 (and also from looking at other packages), it appears that
line length limit is actually 76 characters, not 78. Also, this fixes
attachments broken before for a certain webmail client (roundcube).