### PR TITLE
Bugfix. BCC should not be added in header

### DIFF
--- a/mailer.go
+++ b/mailer.go
@@ -133,15 +133,6 @@ func flattenHeader(msg *mail.Message, bcc string) []byte {
 			buf.WriteString(": ")
 			buf.WriteString(strings.Join(value, ", "))
 			buf.WriteString("\r\n")
-		} else if bcc != "" {
-			for _, to := range value {
-				if strings.Contains(to, bcc) {
-					buf.WriteString(field)
-					buf.WriteString(": ")
-					buf.WriteString(to)
-					buf.WriteString("\r\n")
-				}
-			}
 		}
 	}
 	buf.WriteString("\r\n")


### PR DESCRIPTION
```go
msg.SetHeader("Bcc", []string{"me@secret.com"})
```

When I add this secret address in the BCC-header field it should not be added in the email, currently this is the case.