### PR TITLE
Attachments using readers

### DIFF
--- a/message.go
+++ b/message.go
@@ -263,8 +263,8 @@ func SetCopyFunc(f func(io.Writer) error) FileSetting {
 	}
 }
 
-func (m *Message) appendFile(list []*file, name string, settings []FileSetting) []*file {
-	f := &file{
+func (m *Message) appendOSFile(list []*file, name string, settings []FileSetting) []*file {
+	return m.appendFile(list, &file{
 		Name:   filepath.Base(name),
 		Header: make(map[string][]string),
 		CopyFunc: func(w io.Writer) error {
@@ -278,8 +278,24 @@ func (m *Message) appendFile(list []*file, name string, settings []FileSetting) 
 			}
 			return h.Close()
 		},
-	}
+	}, settings)
+}
 
+func (m *Message) appendReaderFile(list []*file, name string, r io.Reader, settings []FileSetting) []*file {
+	return m.appendFile(list, &file{
+		Name:   name,
+		Header: make(map[string][]string),
+		CopyFunc: func(w io.Writer) error {
+			if _, err := io.Copy(w, r); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}, settings)
+}
+
+func (m *Message) appendFile(list []*file, f *file, settings []FileSetting) []*file {
 	for _, s := range settings {
 		s(f)
 	}
@@ -293,10 +309,20 @@ func (m *Message) appendFile(list []*file, name string, settings []FileSetting) 
 
 // Attach attaches the files to the email.
 func (m *Message) Attach(filename string, settings ...FileSetting) {
-	m.attachments = m.appendFile(m.attachments, filename, settings)
+	m.attachments = m.appendOSFile(m.attachments, filename, settings)
 }
 
 // Embed embeds the images to the email.
 func (m *Message) Embed(filename string, settings ...FileSetting) {
-	m.embedded = m.appendFile(m.embedded, filename, settings)
+	m.embedded = m.appendOSFile(m.embedded, filename, settings)
+}
+
+// AttachWithReader equal to Attach using a io.Reader as content of the file.
+func (m *Message) AttachWithReader(filename string, r io.Reader, settings ...FileSetting) {
+	m.attachments = m.appendReaderFile(m.attachments, filename, r, settings)
+}
+
+// EmbedWithReader equal to Attach using a io.Reader as content of the file.
+func (m *Message) EmbedWithReader(filename string, r io.Reader, settings ...FileSetting) {
+	m.embedded = m.appendReaderFile(m.attachments, filename, r, settings)
 }

--- a/message_test.go
+++ b/message_test.go
@@ -313,6 +313,44 @@ func TestAttachments(t *testing.T) {
 	testMessage(t, m, 1, want)
 }
 
+func TestAttachmentsWithReader(t *testing.T) {
+	m := NewMessage()
+	m.SetHeader("From", "from@example.com")
+	m.SetHeader("To", "to@example.com")
+	m.SetBody("text/plain", "Test")
+	m.AttachWithReader("test.pdf", bytes.NewBuffer([]byte("Reader test.pdf")))
+	m.AttachWithReader("test.zip", bytes.NewBuffer([]byte("Reader test.zip")))
+
+	want := &message{
+		from: "from@example.com",
+		to:   []string{"to@example.com"},
+		content: "From: from@example.com\r\n" +
+			"To: to@example.com\r\n" +
+			"Content-Type: multipart/mixed; boundary=_BOUNDARY_1_\r\n" +
+			"\r\n" +
+			"--_BOUNDARY_1_\r\n" +
+			"Content-Type: text/plain; charset=UTF-8\r\n" +
+			"Content-Transfer-Encoding: quoted-printable\r\n" +
+			"\r\n" +
+			"Test\r\n" +
+			"--_BOUNDARY_1_\r\n" +
+			"Content-Type: application/pdf; name=\"test.pdf\"\r\n" +
+			"Content-Disposition: attachment; filename=\"test.pdf\"\r\n" +
+			"Content-Transfer-Encoding: base64\r\n" +
+			"\r\n" +
+			base64.StdEncoding.EncodeToString([]byte("Reader test.pdf")) + "\r\n" +
+			"--_BOUNDARY_1_\r\n" +
+			"Content-Type: application/zip; name=\"test.zip\"\r\n" +
+			"Content-Disposition: attachment; filename=\"test.zip\"\r\n" +
+			"Content-Transfer-Encoding: base64\r\n" +
+			"\r\n" +
+			base64.StdEncoding.EncodeToString([]byte("Reader test.zip")) + "\r\n" +
+			"--_BOUNDARY_1_--\r\n",
+	}
+
+	testMessage(t, m, 1, want)
+}
+
 func TestEmbedded(t *testing.T) {
 	m := NewMessage()
 	m.SetHeader("From", "from@example.com")
@@ -347,6 +385,38 @@ func TestEmbedded(t *testing.T) {
 			"Content-Transfer-Encoding: base64\r\n" +
 			"\r\n" +
 			base64.StdEncoding.EncodeToString([]byte("Content of image2.jpg")) + "\r\n" +
+			"--_BOUNDARY_1_--\r\n",
+	}
+
+	testMessage(t, m, 1, want)
+}
+
+func TestEmbeddedWithReader(t *testing.T) {
+	m := NewMessage()
+	m.SetHeader("From", "from@example.com")
+	m.SetHeader("To", "to@example.com")
+	m.EmbedWithReader("image1.jpg", bytes.NewBuffer([]byte("Reader image1.jpg")))
+	m.SetBody("text/plain", "Test")
+
+	want := &message{
+		from: "from@example.com",
+		to:   []string{"to@example.com"},
+		content: "From: from@example.com\r\n" +
+			"To: to@example.com\r\n" +
+			"Content-Type: multipart/related; boundary=_BOUNDARY_1_\r\n" +
+			"\r\n" +
+			"--_BOUNDARY_1_\r\n" +
+			"Content-Type: text/plain; charset=UTF-8\r\n" +
+			"Content-Transfer-Encoding: quoted-printable\r\n" +
+			"\r\n" +
+			"Test\r\n" +
+			"--_BOUNDARY_1_\r\n" +
+			"Content-Type: image/jpeg; name=\"image1.jpg\"\r\n" +
+			"Content-Disposition: inline; filename=\"image1.jpg\"\r\n" +
+			"Content-ID: <image1.jpg>\r\n" +
+			"Content-Transfer-Encoding: base64\r\n" +
+			"\r\n" +
+			base64.StdEncoding.EncodeToString([]byte("Reader image1.jpg")) + "\r\n" +
 			"--_BOUNDARY_1_--\r\n",
 	}
 


### PR DESCRIPTION
This PRs adds an alternative method of attach or embed files in `Message` using a `io.Reader` allowing to attach files made on the fly and without needing to save a file to disk.