### PR TITLE
Make client's identity configurable

### DIFF
--- a/smtp_test.go
+++ b/smtp_test.go
@@ -56,8 +56,10 @@ func TestDialerSSL(t *testing.T) {
 
 func TestDialerConfig(t *testing.T) {
 	d := NewPlainDialer(testHost, testPort, "user", "pwd")
+	d.LocalName = "test"
 	d.TLSConfig = testConfig
 	testSendMail(t, d, []string{
+		"Hello test",
 		"Extension STARTTLS",
 		"StartTLS",
 		"Extension AUTH",
@@ -75,8 +77,10 @@ func TestDialerConfig(t *testing.T) {
 
 func TestDialerSSLConfig(t *testing.T) {
 	d := NewPlainDialer(testHost, testSSLPort, "user", "pwd")
+	d.LocalName = "test"
 	d.TLSConfig = testConfig
 	testSendMail(t, d, []string{
+		"Hello test",
 		"Extension AUTH",
 		"Auth",
 		"Mail " + testFrom,
@@ -121,6 +125,11 @@ type mockClient struct {
 func (c *mockClient) Extension(ext string) (bool, string) {
 	c.do("Extension " + ext)
 	return true, ""
+}
+
+func (c *mockClient) Hello(localName string) error {
+	c.do("Hello " + localName)
+	return nil
 }
 
 func (c *mockClient) StartTLS(config *tls.Config) error {


### PR DESCRIPTION
The net/smtp library sends "localhost" unless otherwise instructed. This
commit adds a new "LocalName" field to the Dialer struct that allows
users to override what gets sent with SMTP's HELO command.