### PR TITLE
Added an option to manually set filename of attachment

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -167,6 +167,10 @@ func ExampleMessage_Attach() {
 	m.Attach("/tmp/image.jpg")
 }
 
+func ExampleMessage_AttachAndRename() {
+	m.Attach("/tmp/image.jpg", gomail.Rename("picture.jpg"))
+}
+
 func ExampleMessage_Embed() {
 	m.Embed("/tmp/image.jpg")
 	m.SetBody("text/html", `<img src="cid:image.jpg" alt="My image" />`)

--- a/message.go
+++ b/message.go
@@ -264,6 +264,14 @@ func SetHeader(h map[string][]string) FileSetting {
 	}
 }
 
+// Rename is a file setting to set the name of the attachment if the name is
+// different than the filename on disk.
+func Rename(name string) FileSetting {
+	return func(f *file) {
+		f.Name = name
+	}
+}
+
 // SetCopyFunc is a file setting to replace the function that runs when the
 // message is sent. It should copy the content of the file to the io.Writer.
 //

--- a/message_test.go
+++ b/message_test.go
@@ -290,6 +290,40 @@ func TestAttachment(t *testing.T) {
 	testMessage(t, m, 1, want)
 }
 
+func TestRename(t *testing.T) {
+	m := NewMessage()
+	m.SetHeader("From", "from@example.com")
+	m.SetHeader("To", "to@example.com")
+	m.SetBody("text/plain", "Test")
+	name, copy := mockCopyFile("/tmp/test.pdf")
+	rename := Rename("another.pdf")
+	m.Attach(name, copy, rename)
+
+	want := &message{
+		from: "from@example.com",
+		to:   []string{"to@example.com"},
+		content: "From: from@example.com\r\n" +
+			"To: to@example.com\r\n" +
+			"Content-Type: multipart/mixed;\r\n" +
+			" boundary=_BOUNDARY_1_\r\n" +
+			"\r\n" +
+			"--_BOUNDARY_1_\r\n" +
+			"Content-Type: text/plain; charset=UTF-8\r\n" +
+			"Content-Transfer-Encoding: quoted-printable\r\n" +
+			"\r\n" +
+			"Test\r\n" +
+			"--_BOUNDARY_1_\r\n" +
+			"Content-Type: application/pdf; name=\"another.pdf\"\r\n" +
+			"Content-Disposition: attachment; filename=\"another.pdf\"\r\n" +
+			"Content-Transfer-Encoding: base64\r\n" +
+			"\r\n" +
+			base64.StdEncoding.EncodeToString([]byte("Content of test.pdf")) + "\r\n" +
+			"--_BOUNDARY_1_--\r\n",
+	}
+
+	testMessage(t, m, 1, want)
+}
+
 func TestAttachmentsOnly(t *testing.T) {
 	m := NewMessage()
 	m.SetHeader("From", "from@example.com")


### PR DESCRIPTION
If the name of the attachment is different the the actual filename on disk, we should have an easy option to change it