### PR TITLE
Accept io.Reader for Attach and Embed

### DIFF
--- a/message.go
+++ b/message.go
@@ -283,8 +283,28 @@ func SetCopyFunc(f func(io.Writer) error) FileSetting {
 	}
 }
 
-func (m *Message) appendFile(list []*file, name string, settings []FileSetting) []*file {
-	f := &file{
+// AttachReader attaches a file using an io.Reader
+func (m *Message) AttachReader(name string, r io.Reader, settings ...FileSetting) {
+	m.attachments = m.appendFile(m.attachments, fileFromReader(name, r), settings)
+}
+
+// Attach attaches the files to the email.
+func (m *Message) Attach(filename string, settings ...FileSetting) {
+	m.attachments = m.appendFile(m.attachments, fileFromFilename(filename), settings)
+}
+
+// EmbedReader embeds the images to the email.
+func (m *Message) EmbedReader(name string, r io.Reader, settings ...FileSetting) {
+	m.embedded = m.appendFile(m.embedded, fileFromReader(name, r), settings)
+}
+
+// Embed embeds the images to the email.
+func (m *Message) Embed(filename string, settings ...FileSetting) {
+	m.embedded = m.appendFile(m.embedded, fileFromFilename(filename), settings)
+}
+
+func fileFromFilename(name string) *file {
+	return &file{
 		Name:   filepath.Base(name),
 		Header: make(map[string][]string),
 		CopyFunc: func(w io.Writer) error {
@@ -299,7 +319,22 @@ func (m *Message) appendFile(list []*file, name string, settings []FileSetting) 
 			return h.Close()
 		},
 	}
+}
 
+func fileFromReader(name string, r io.Reader) *file {
+	return &file{
+		Name:   filepath.Base(name),
+		Header: make(map[string][]string),
+		CopyFunc: func(w io.Writer) error {
+			if _, err := io.Copy(w, r); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+}
+
+func (m *Message) appendFile(list []*file, f *file, settings []FileSetting) []*file {
 	for _, s := range settings {
 		s(f)
 	}
@@ -309,14 +344,4 @@ func (m *Message) appendFile(list []*file, name string, settings []FileSetting) 
 	}
 
 	return append(list, f)
-}
-
-// Attach attaches the files to the email.
-func (m *Message) Attach(filename string, settings ...FileSetting) {
-	m.attachments = m.appendFile(m.attachments, filename, settings)
-}
-
-// Embed embeds the images to the email.
-func (m *Message) Embed(filename string, settings ...FileSetting) {
-	m.embedded = m.appendFile(m.embedded, filename, settings)
 }

--- a/message_test.go
+++ b/message_test.go
@@ -237,6 +237,30 @@ func TestBodyWriter(t *testing.T) {
 	testMessage(t, m, 1, want)
 }
 
+func TestAttachmentReader(t *testing.T) {
+	m := NewMessage()
+	m.SetHeader("From", "from@example.com")
+	m.SetHeader("To", "to@example.com")
+
+	var b bytes.Buffer
+	b.Write([]byte("Test file"))
+	m.AttachReader("file.txt", &b)
+
+	want := &message{
+		from: "from@example.com",
+		to:   []string{"to@example.com"},
+		content: "From: from@example.com\r\n" +
+			"To: to@example.com\r\n" +
+			"Content-Type: text/plain; charset=utf-8; name=\"file.txt\"\r\n" +
+			"Content-Disposition: attachment; filename=\"file.txt\"\r\n" +
+			"Content-Transfer-Encoding: base64\r\n" +
+			"\r\n" +
+			base64.StdEncoding.EncodeToString([]byte("Test file")),
+	}
+
+	testMessage(t, m, 0, want)
+}
+
 func TestAttachmentOnly(t *testing.T) {
 	m := NewMessage()
 	m.SetHeader("From", "from@example.com")
@@ -394,6 +418,31 @@ func TestAttachments(t *testing.T) {
 	}
 
 	testMessage(t, m, 1, want)
+}
+
+func TestEmbeddedReader(t *testing.T) {
+	m := NewMessage()
+	m.SetHeader("From", "from@example.com")
+	m.SetHeader("To", "to@example.com")
+
+	var b bytes.Buffer
+	b.Write([]byte("Test file"))
+	m.EmbedReader("file.txt", &b)
+
+	want := &message{
+		from: "from@example.com",
+		to:   []string{"to@example.com"},
+		content: "From: from@example.com\r\n" +
+			"To: to@example.com\r\n" +
+			"Content-Type: text/plain; charset=utf-8; name=\"file.txt\"\r\n" +
+			"Content-Transfer-Encoding: base64\r\n" +
+			"Content-Disposition: inline; filename=\"file.txt\"\r\n" +
+			"Content-ID: <file.txt>\r\n" +
+			"\r\n" +
+			base64.StdEncoding.EncodeToString([]byte("Test file")),
+	}
+
+	testMessage(t, m, 0, want)
 }
 
 func TestEmbedded(t *testing.T) {


### PR DESCRIPTION
Here's a patch that will accept an `io.Reader` for both Attach and Embed with accompanying tests.

I kept the original methods named as `Attach` and added `AttachReader` though it is up for discussion!

I feel in Go the idiomatic thing would be to have

```
Attach(name string, r io.Reader, settings ...FileSetting)
```

and 

```
AttachFile(filename string, settings ...FileSetting)
```

So that `AttachFile` is really only a convenience method. I think most people in Go would be using something io.Reader compatible?

But it works for the time being and it's sufficient enough

I wanted to add an example to the example file. But since it's pointing to a gopkg.in version that couldn't be possible at the moment without breaking the test suite.

This is talked about in issue #69 