### PR TITLE
Break out SMTP Client Reset Method

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/fjace05/gomail"
+	"gopkg.in/gomail.v2"
 )
 
 func Example() {
@@ -50,11 +50,6 @@ func Example_daemon() {
 					open = true
 				}
 				if err := gomail.Send(s, m); err != nil {
-					/*
-					If a message fails to send, the SMTP channel can be reset so additional messages
-					can be attempted.
-					 */
-					s.Reset()
 					log.Print(err)
 				}
 			// Close the connection to the SMTP server if no email was sent in

--- a/example_test.go
+++ b/example_test.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"time"
 
-	"gopkg.in/gomail.v2"
+	"github.com/fjace05/gomail"
 )
 
 func Example() {
@@ -50,6 +50,11 @@ func Example_daemon() {
 					open = true
 				}
 				if err := gomail.Send(s, m); err != nil {
+					/*
+					If a message fails to send, the SMTP channel can be reset so additional messages
+					can be attempted.
+					 */
+					s.Reset()
 					log.Print(err)
 				}
 			// Close the connection to the SMTP server if no email was sent in

--- a/send.go
+++ b/send.go
@@ -18,6 +18,7 @@ type Sender interface {
 type SendCloser interface {
 	Sender
 	Close() error
+	Reset() error
 }
 
 // A SendFunc is a function that sends emails to the given addresses.

--- a/send_test.go
+++ b/send_test.go
@@ -31,10 +31,15 @@ func (s mockSender) Send(from string, to []string, msg io.WriterTo) error {
 type mockSendCloser struct {
 	mockSender
 	close func() error
+	reset func() error
 }
 
 func (s *mockSendCloser) Close() error {
 	return s.close()
+}
+
+func (s *mockSendCloser) Reset() error {
+	return s.reset()
 }
 
 func TestSend(t *testing.T) {
@@ -42,6 +47,10 @@ func TestSend(t *testing.T) {
 		mockSender: stubSend(t, testFrom, []string{testTo1, testTo2}, testMsg),
 		close: func() error {
 			t.Error("Close() should not be called in Send()")
+			return nil
+		},
+		reset: func() error {
+			t.Error("Reset() should not be called in Send()")
 			return nil
 		},
 	}

--- a/smtp.go
+++ b/smtp.go
@@ -180,6 +180,10 @@ func (c *smtpSender) Close() error {
 	return c.Quit()
 }
 
+func (c *smtpSender) Reset() error {
+	return c.smtpClient.Reset()
+}
+
 // Stubbed out for tests.
 var (
 	netDialTimeout = net.DialTimeout
@@ -196,6 +200,7 @@ type smtpClient interface {
 	Auth(smtp.Auth) error
 	Mail(string) error
 	Rcpt(string) error
+	Reset() error
 	Data() (io.WriteCloser, error)
 	Quit() error
 	Close() error

--- a/smtp_test.go
+++ b/smtp_test.go
@@ -52,7 +52,6 @@ func TestDialerSSL(t *testing.T) {
 		"Data",
 		"Write message",
 		"Close writer",
-		"Reset",
 		"Quit",
 		"Close",
 	})

--- a/smtp_test.go
+++ b/smtp_test.go
@@ -52,6 +52,7 @@ func TestDialerSSL(t *testing.T) {
 		"Data",
 		"Write message",
 		"Close writer",
+		"Reset",
 		"Quit",
 		"Close",
 	})
@@ -138,6 +139,19 @@ func TestDialerTimeout(t *testing.T) {
 	})
 }
 
+func TestDialerReset(t *testing.T) {
+	d := NewDialer(testHost, testPort, "user", "pwd")
+	doTestSMTPReset(t, d, []string{
+		"Extension STARTTLS",
+		"StartTLS",
+		"Extension AUTH",
+		"Auth",
+		"Reset",
+		"Quit",
+		"Close",
+	})
+}
+
 type mockClient struct {
 	t       *testing.T
 	i       int
@@ -195,6 +209,11 @@ func (c *mockClient) Quit() error {
 	return nil
 }
 
+func (c *mockClient) Reset() error {
+	c.do("Reset")
+	return nil
+}
+
 func (c *mockClient) Close() error {
 	c.do("Close")
 	return nil
@@ -237,6 +256,55 @@ func testSendMail(t *testing.T, d *Dialer, want []string) {
 
 func testSendMailTimeout(t *testing.T, d *Dialer, want []string) {
 	doTestSendMail(t, d, want, true)
+}
+
+func doTestSMTPReset(t *testing.T, d *Dialer, want []string){
+	testClient := &mockClient{
+		t:       t,
+		want:    want,
+		addr:    addr(d.Host, d.Port),
+		config:  d.TLSConfig,
+		timeout: false,
+	}
+
+	netDialTimeout = func(network, address string, d time.Duration) (net.Conn, error) {
+		if network != "tcp" {
+			t.Errorf("Invalid network, got %q, want tcp", network)
+		}
+		if address != testClient.addr {
+			t.Errorf("Invalid address, got %q, want %q",
+				address, testClient.addr)
+		}
+		return testConn, nil
+	}
+
+	tlsClient = func(conn net.Conn, config *tls.Config) *tls.Conn {
+		if conn != testConn {
+			t.Errorf("Invalid conn, got %#v, want %#v", conn, testConn)
+		}
+		assertConfig(t, config, testClient.config)
+		return testTLSConn
+	}
+
+	smtpNewClient = func(conn net.Conn, host string) (smtpClient, error) {
+		if host != testHost {
+			t.Errorf("Invalid host, got %q, want %q", host, testHost)
+		}
+		return testClient, nil
+	}
+	//Start "daemon" mode
+	s, err := d.Dial()
+	if err != nil {
+		t.Error(err)
+	}
+
+	/*
+	Call the reset for testing purposes. In practice, this should be called after an error while attempting to send
+	 a message. But per RFC 5321 RSET can be called at any time.
+	 */
+	s.Reset()
+	s.Close()
+
 }
 
 func doTestSendMail(t *testing.T, d *Dialer, want []string, timeout bool) {


### PR DESCRIPTION
This is a pull request to remedy Issue #77. It breaks out the already existent Reset method on the Go Lang net/smtp Client library. For this fix, the method is added to the SenderCloser interface to make it accessible when running the "Daemon Mode". This will allow users to reset the channel instead of completely closing and reopening the channel after an error occurs while sending a message.