### PR TITLE
Export NetDialTimeout to public

### DIFF
--- a/smtp.go
+++ b/smtp.go
@@ -58,7 +58,7 @@ func NewPlainDialer(host string, port int, username, password string) *Dialer {
 // Dial dials and authenticates to an SMTP server. The returned SendCloser
 // should be closed when done using it.
 func (d *Dialer) Dial() (SendCloser, error) {
-	conn, err := netDialTimeout("tcp", addr(d.Host, d.Port), 10*time.Second)
+	conn, err := NetDialTimeout("tcp", addr(d.Host, d.Port), 10*time.Second)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (c *smtpSender) Close() error {
 
 // Stubbed out for tests.
 var (
-	netDialTimeout = net.DialTimeout
+	NetDialTimeout = net.DialTimeout
 	tlsClient      = tls.Client
 	smtpNewClient  = func(conn net.Conn, host string) (smtpClient, error) {
 		return smtp.NewClient(conn, host)

--- a/smtp_test.go
+++ b/smtp_test.go
@@ -248,7 +248,7 @@ func doTestSendMail(t *testing.T, d *Dialer, want []string, timeout bool) {
 		timeout: timeout,
 	}
 
-	netDialTimeout = func(network, address string, d time.Duration) (net.Conn, error) {
+	NetDialTimeout = func(network, address string, d time.Duration) (net.Conn, error) {
 		if network != "tcp" {
 			t.Errorf("Invalid network, got %q, want tcp", network)
 		}


### PR DESCRIPTION
Export the netdial function, this allow setup a custom dialer (like tor socks proxy):

    dialer, _ := proxy.FromURL("socks5://127.0.0.1:9050", proxy.Direct) 
    gomail.NetDialTimeout = func(network, address string, timeout time.Duration) (net.Conn, error) {
      return dialer.Dial(network, address)
    }