### PR TITLE
add SetBoundary(boundary string) method

### DIFF
--- a/message.go
+++ b/message.go
@@ -18,6 +18,7 @@ type Message struct {
 	encoding    Encoding
 	hEncoder    mimeEncoder
 	buf         bytes.Buffer
+	boundary    string
 }
 
 type header map[string][]string
@@ -69,6 +70,13 @@ func (m *Message) applySettings(settings []MessageSetting) {
 // email.
 type MessageSetting func(m *Message)
 
+// SetBoundary is a message setting to set mime separator string
+func SetBoundary(boundary string) MessageSetting {
+	return func(m *Message) {
+		m.boundary = boundary
+	}
+}
+
 // SetCharset is a message setting to set the charset of the email.
 func SetCharset(charset string) MessageSetting {
 	return func(m *Message) {
@@ -96,6 +104,11 @@ const (
 	// will still be encoded using quoted-printable encoding.
 	Unencoded Encoding = "8bit"
 )
+
+// SetBoundary allows to set custom boundary for multypart message generated
+func (m *Message) SetBoundary(boundary string) {
+	m.boundary = boundary
+}
 
 // SetHeader sets a value to the given header field.
 func (m *Message) SetHeader(field string, value ...string) {

--- a/message_test.go
+++ b/message_test.go
@@ -200,6 +200,38 @@ func TestPartSetting(t *testing.T) {
 	testMessage(t, m, 1, want)
 }
 
+func TestPartSettingWithCustomBoundary(t *testing.T) {
+	m := NewMessage()
+	m.SetBoundary("lalalaDaiMne3Ryblya")
+	m.SetHeader("From", "from@example.com")
+	m.SetHeader("To", "to@example.com")
+	m.SetBody("text/plain; format=flowed", "¡Hola, señor!", SetPartEncoding(Unencoded))
+	m.AddAlternative("text/html", "¡<b>Hola</b>, <i>señor</i>!</h1>")
+
+	want := &message{
+		from: "from@example.com",
+		to:   []string{"to@example.com"},
+		content: "From: from@example.com\r\n" +
+			"To: to@example.com\r\n" +
+			"Content-Type: multipart/alternative;\r\n" +
+			" boundary=lalalaDaiMne3Ryblya\r\n" +
+			"\r\n" +
+			"--lalalaDaiMne3Ryblya\r\n" +
+			"Content-Type: text/plain; format=flowed; charset=UTF-8\r\n" +
+			"Content-Transfer-Encoding: 8bit\r\n" +
+			"\r\n" +
+			"¡Hola, señor!\r\n" +
+			"--lalalaDaiMne3Ryblya\r\n" +
+			"Content-Type: text/html; charset=UTF-8\r\n" +
+			"Content-Transfer-Encoding: quoted-printable\r\n" +
+			"\r\n" +
+			"=C2=A1<b>Hola</b>, <i>se=C3=B1or</i>!</h1>\r\n" +
+			"--lalalaDaiMne3Ryblya--\r\n",
+	}
+
+	testMessage(t, m, 1, want)
+}
+
 func TestBodyWriter(t *testing.T) {
 	m := NewMessage()
 	m.SetHeader("From", "from@example.com")

--- a/writeto.go
+++ b/writeto.go
@@ -28,15 +28,15 @@ func (w *messageWriter) writeMessage(m *Message) {
 	w.writeHeaders(m.header)
 
 	if m.hasMixedPart() {
-		w.openMultipart("mixed")
+		w.openMultipart("mixed", m.boundary)
 	}
 
 	if m.hasRelatedPart() {
-		w.openMultipart("related")
+		w.openMultipart("related", m.boundary)
 	}
 
 	if m.hasAlternativePart() {
-		w.openMultipart("alternative")
+		w.openMultipart("alternative", m.boundary)
 	}
 	for _, part := range m.parts {
 		w.writePart(part, m.charset)
@@ -77,8 +77,13 @@ type messageWriter struct {
 	err        error
 }
 
-func (w *messageWriter) openMultipart(mimeType string) {
+func (w *messageWriter) openMultipart(mimeType, boundary string) {
 	mw := multipart.NewWriter(w)
+	if boundary == "" {
+		boundary = mw.Boundary()
+	} else {
+		mw.SetBoundary(boundary)
+	}
 	contentType := "multipart/" + mimeType + ";\r\n boundary=" + mw.Boundary()
 	w.writers[w.depth] = mw
 

--- a/writeto.go
+++ b/writeto.go
@@ -79,9 +79,7 @@ type messageWriter struct {
 
 func (w *messageWriter) openMultipart(mimeType, boundary string) {
 	mw := multipart.NewWriter(w)
-	if boundary == "" {
-		boundary = mw.Boundary()
-	} else {
+	if boundary != "" {
 		mw.SetBoundary(boundary)
 	}
 	contentType := "multipart/" + mimeType + ";\r\n boundary=" + mw.Boundary()


### PR DESCRIPTION
This method is used  to manually set mime boundary string. If we don't call this method, the default behaviour is used - aka boundary is generated by https://godoc.org/mime/multipart package.
Also i have added unit tests to ensure it works as expected. And all old unit tests are passing.

Reason i want this method to be present, is because i have to deal with legacy report processing java application, and it hangs sometimes, when i send messages generated by your package.
As far as i understand how this java dinosaur works, it throws errors because boundary generated is 30 bytes long.

https://golang.org/src/mime/multipart/writer.go#L78
```golang
func randomBoundary() string {

	var buf [30]byte

	_, err := io.ReadFull(rand.Reader, buf[:])

	if err != nil {

		panic(err)

	}

	return fmt.Sprintf("%x", buf[:])

}

```
And it seems too big for java dinosaur code. Or maybe badly written regex in it... hard to say. 
But if i could set boundary manually, you will make my day!
thanks