### PR TITLE
Fix errors by use port 465

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,10 +1,10 @@
 package gomail
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"net/smtp"
+	"strings"
 )
 
 // loginAuth is an smtp.Auth that implements the LOGIN authentication mechanism.
@@ -38,12 +38,17 @@ func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 		return nil, nil
 	}
 
+	cmd := string(fromServer)
+	cmd = strings.TrimSpace(cmd)
+	cmd = strings.TrimSuffix(cmd, ":")
+	cmd = strings.ToLower(cmd)
+
 	switch {
-	case bytes.Equal(fromServer, []byte("Username:")):
+	case strings.EqualFold(cmd,"username"):
 		return []byte(a.username), nil
-	case bytes.Equal(fromServer, []byte("Password:")):
+	case strings.EqualFold(cmd,"password"):
 		return []byte(a.password), nil
 	default:
-		return nil, fmt.Errorf("gomail: unexpected server challenge: %s", fromServer)
+		return nil, fmt.Errorf("gomail: unexpected server challenge: %s", cmd)
 	}
 }

--- a/smtp.go
+++ b/smtp.go
@@ -91,8 +91,7 @@ func (d *Dialer) Dial() (SendCloser, error) {
 		if ok, auths := c.Extension("AUTH"); ok {
 			if strings.Contains(auths, "CRAM-MD5") {
 				d.Auth = smtp.CRAMMD5Auth(d.Username, d.Password)
-			} else if strings.Contains(auths, "LOGIN") &&
-				!strings.Contains(auths, "PLAIN") {
+			} else if strings.Contains(auths, "LOGIN") {
 				d.Auth = &loginAuth{
 					username: d.Username,
 					password: d.Password,


### PR DESCRIPTION
1. Fix errors caused by auths containing both LOGIN and PALIN fields
2. Fix errors caused by fromServer case