### PR TITLE
Correct MIME-Version to upper case

### DIFF
--- a/message_test.go
+++ b/message_test.go
@@ -625,7 +625,7 @@ func stubSendMail(t *testing.T, bCount int, want *message) SendFunc {
 			t.Error(err)
 		}
 		got := buf.String()
-		wantMsg := string("Mime-Version: 1.0\r\n" +
+		wantMsg := string("MIME-Version: 1.0\r\n" +
 			"Date: Wed, 25 Jun 2014 17:46:00 +0000\r\n" +
 			want.content)
 		if bCount > 0 {

--- a/send_test.go
+++ b/send_test.go
@@ -14,7 +14,7 @@ const (
 	testBody = "Test message"
 	testMsg  = "To: " + testTo1 + ", " + testTo2 + "\r\n" +
 		"From: " + testFrom + "\r\n" +
-		"Mime-Version: 1.0\r\n" +
+		"MIME-Version: 1.0\r\n" +
 		"Date: Wed, 25 Jun 2014 17:46:00 +0000\r\n" +
 		"Content-Type: text/plain; charset=UTF-8\r\n" +
 		"Content-Transfer-Encoding: quoted-printable\r\n" +

--- a/writeto.go
+++ b/writeto.go
@@ -19,8 +19,8 @@ func (m *Message) WriteTo(w io.Writer) (int64, error) {
 }
 
 func (w *messageWriter) writeMessage(m *Message) {
-	if _, ok := m.header["Mime-Version"]; !ok {
-		w.writeString("Mime-Version: 1.0\r\n")
+	if _, ok := m.header["MIME-Version"]; !ok {
+		w.writeString("MIME-Version: 1.0\r\n")
 	}
 	if _, ok := m.header["Date"]; !ok {
 		w.writeHeader("Date", m.FormatDate(now()))


### PR DESCRIPTION
As of RFC 822 the "MIME-Version" has to be in upper case: https://www.w3.org/Protocols/rfc1341/3_MIME-Version.html  
This adds 0.5 points to the spam score in rspamd.