### PR TITLE
Make encodeHeader return a new array

### DIFF
--- a/message.go
+++ b/message.go
@@ -99,14 +99,16 @@ const (
 
 // SetHeader sets a value to the given header field.
 func (m *Message) SetHeader(field string, value ...string) {
-	m.encodeHeader(value)
-	m.header[field] = value
+	m.header[field] = m.encodeHeader(value)
 }
 
-func (m *Message) encodeHeader(values []string) {
+func (m *Message) encodeHeader(values []string) []string {
+	encoded := make([]string, len(values))
 	for i := range values {
-		values[i] = m.encodeString(values[i])
+		encoded[i] = m.encodeString(values[i])
 	}
+
+	return encoded
 }
 
 func (m *Message) encodeString(value string) string {


### PR DESCRIPTION
## Problem
Arrays in Go are mutable. This method currently replaces all values passed to `SetHeader` by their encoded version.

This can be problematic in a scenario that the array passed to `SetHeader` is reused somewhere else in the code. 

Ex : 
```golang
rcptTo := []string{"alice@example.com, "bob@example.com"}

message := gomail.NewMessage()
message.SetHeader("To", rcptTo)
// ...
var buffer bytes.Buffer
message.WriteTo(&buffer)

mail.SendMail("myhost.com:25", nil, "postmaster@example.com", rcptTo, buffer.Bytes())
```

In the above example, the recipients passed to `SendMail` will be encoded and result in a `501 5.1.3 Bad recipient address syntax` from any postfix server.

In my opinion, the expected behaviour of `SetHeader` is not to mutate the values passed as arguments.

## Solution
The proposed change creates a new array of string of the same length as the header values passed in and fill it with the encoded values, therefore not touching the raw ones.