### PR TITLE
Convenience method to attach directly from memory

### DIFF
--- a/message.go
+++ b/message.go
@@ -316,6 +316,18 @@ func (m *Message) Attach(filename string, settings ...FileSetting) {
 	m.attachments = m.appendFile(m.attachments, filename, settings)
 }
 
+// Attach data to the e-mail as if it is a file
+func (m *Message) AttachDirect(name string, content []byte, contentType string) {
+	m.Attach(
+		name,
+		SetCopyFunc(func(w io.Writer) error {
+			_, err := w.Write(content)
+			return err
+		}),
+		SetHeader(map[string][]string{"Content-Type": {contentType}}),
+	)
+}
+
 // Embed embeds the images to the email.
 func (m *Message) Embed(filename string, settings ...FileSetting) {
 	m.embedded = m.appendFile(m.embedded, filename, settings)

--- a/message_test.go
+++ b/message_test.go
@@ -290,6 +290,59 @@ func TestAttachment(t *testing.T) {
 	testMessage(t, m, 1, want)
 }
 
+func TestDirectAttachmentOnly(t *testing.T) {
+	m := NewMessage()
+	m.SetHeader("From", "from@example.com")
+	m.SetHeader("To", "to@example.com")
+	m.AttachDirect("test.txt", []byte("Content of test.txt"), "text/plain")
+
+	want := &message{
+		from: "from@example.com",
+		to:   []string{"to@example.com"},
+		content: "From: from@example.com\r\n" +
+			"To: to@example.com\r\n" +
+			"Content-Type: text/plain\r\n" +
+			"Content-Disposition: attachment; filename=\"test.txt\"\r\n" +
+			"Content-Transfer-Encoding: base64\r\n" +
+			"\r\n" +
+			base64.StdEncoding.EncodeToString([]byte("Content of test.txt")),
+	}
+
+	testMessage(t, m, 0, want)
+}
+
+func TestDirectAttachment(t *testing.T) {
+	m := NewMessage()
+	m.SetHeader("From", "from@example.com")
+	m.SetHeader("To", "to@example.com")
+	m.SetBody("text/plain", "Test")
+	m.AttachDirect("test.txt", []byte("Content of test.txt"), "text/plain")
+
+	want := &message{
+		from: "from@example.com",
+		to:   []string{"to@example.com"},
+		content: "From: from@example.com\r\n" +
+			"To: to@example.com\r\n" +
+			"Content-Type: multipart/mixed;\r\n" +
+			" boundary=_BOUNDARY_1_\r\n" +
+			"\r\n" +
+			"--_BOUNDARY_1_\r\n" +
+			"Content-Type: text/plain; charset=UTF-8\r\n" +
+			"Content-Transfer-Encoding: quoted-printable\r\n" +
+			"\r\n" +
+			"Test\r\n" +
+			"--_BOUNDARY_1_\r\n" +
+			"Content-Type: text/plain\r\n" +
+			"Content-Disposition: attachment; filename=\"test.txt\"\r\n" +
+			"Content-Transfer-Encoding: base64\r\n" +
+			"\r\n" +
+			base64.StdEncoding.EncodeToString([]byte("Content of test.txt")) + "\r\n" +
+			"--_BOUNDARY_1_--\r\n",
+	}
+
+	testMessage(t, m, 1, want)
+}
+
 func TestRename(t *testing.T) {
 	m := NewMessage()
 	m.SetHeader("From", "from@example.com")


### PR DESCRIPTION
Many times when I want to attach a file, the data to be attached is already in memory. It would be nice to have a convenience method to elegantly do that

Example Use case:  A CSV that was generated from query results