### PR TITLE
reapply settings after reset

### DIFF
--- a/message.go
+++ b/message.go
@@ -36,7 +36,7 @@ func NewMessage(settings ...MessageSetting) *Message {
 		header:   make(header),
 		charset:  "UTF-8",
 		encoding: QuotedPrintable,
-		settings: settings
+		settings: settings,
 	}
 
 	m.applySettings(settings)

--- a/message.go
+++ b/message.go
@@ -10,6 +10,7 @@ import (
 
 // Message represents an email.
 type Message struct {
+	settings    []MessageSetting
 	header      header
 	parts       []*part
 	attachments []*file
@@ -35,6 +36,7 @@ func NewMessage(settings ...MessageSetting) *Message {
 		header:   make(header),
 		charset:  "UTF-8",
 		encoding: QuotedPrintable,
+		settings: settings
 	}
 
 	m.applySettings(settings)
@@ -57,6 +59,7 @@ func (m *Message) Reset() {
 	m.parts = nil
 	m.attachments = nil
 	m.embedded = nil
+	m.applySettings(m.settings)
 }
 
 func (m *Message) applySettings(settings []MessageSetting) {


### PR DESCRIPTION
based on documentation

```go
// Reset resets the message so it can be reused. The message keeps its previous
// settings so it is in the same state that after a call to NewMessage.
```